### PR TITLE
generic grep: support "modifier.name" matching - fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Probably the most common way to use this tool is to run it with the `--find=<js-
 
 ⚠️ Make sure to only allow trusted inputs to `--find=<js-filter-statement>` as this argument is being evaluated as javascript!
 
+⚠️ Check out the proper order for arguments when using `--find`, `--rule`. See [Usage](#usage).
+
 ### Examples
 
 Run the default rules and display some stats?
@@ -138,7 +140,7 @@ Special contract functions can be references as:
 ```javascript
 
 ⇒  solgrep --help
-Usage: solgrep [options] <folder|...>
+Usage: solgrep <folder|...> [options]
 
 Options:
   -r, --rule        Enable rules                           [array] [default: []]
@@ -151,6 +153,19 @@ Options:
 
   ```
 
+⚠️ when using multi-options (`--find`, `--rule`) make sure to use this format:
+
+```
+⇒  solgrep <folder|...> [options]
+```
+
+or
+
+```
+⇒  solgrep [options] -- <folder|...> 
+```
+
+or else additional options might be interpreted as additional `--find` options!
 
 ## Library 
 

--- a/src/rules/builtin.js
+++ b/src/rules/builtin.js
@@ -38,6 +38,8 @@ class GenericGrep extends BaseRule {
     _getPatternType(p) {
         if (p.includes("function.")) {
             return "function"
+        } else if (p.includes("modifier.")) {
+            return "modifier"
         } else if (p.includes("contract.")) {
             return "contract"
         } else if (p.includes("sourceUnit")) {
@@ -49,13 +51,14 @@ class GenericGrep extends BaseRule {
         let context = {
             sourceUnit: sourceUnit,
             contract: undefined,
-            function: undefined
+            function: undefined,
+            modifier: undefined
         }
 
 
         for (let pat of this.patterns) {
 
-            let patternType = this._getPatternType(pat);
+            var patternType = this._getPatternType(pat);
             if (patternType === "sourceUnit") {
                 let ret = safeEval(pat, context);
                 if (ret) { //allows match & extract (fuzzy)
@@ -90,6 +93,19 @@ class GenericGrep extends BaseRule {
                         let ret = safeEval(pat, context);
                         if (ret) {
                             this.solgrep.report(sourceUnit, this, `match-function: ${contract.name}.${_function.name}`, `${ret}`, typeof ret === 'object' && ret.hasOwnKey('loc') ? ret.loc : _function.ast.loc);
+                        }
+                    }
+                });
+
+                Object.values(contract.modifiers).forEach(_modifier => {
+                    // Modifier
+                    //update context
+                    context.modifier = _modifier;
+                    
+                    if (patternType === "modifier") {
+                        let ret = safeEval(pat, context);
+                        if (ret) {
+                            this.solgrep.report(sourceUnit, this, `match-modifier: ${contract.name}.${_modifier.name}`, `${ret}`, typeof ret === 'object' && ret.hasOwnKey('loc') ? ret.loc : _modifier.ast.loc);
                         }
                     }
                 });

--- a/src/rules/builtin.js
+++ b/src/rules/builtin.js
@@ -51,7 +51,7 @@ class GenericGrep extends BaseRule {
         let context = {
             sourceUnit: sourceUnit,
             contract: undefined,
-            function: undefined,
+            _function: undefined,
             modifier: undefined
         }
 


### PR DESCRIPTION
```
# solgrep test.sol  --find="modifier.name"


🧠 SolGrep v0.0.6 ready!

  Enabled Modules:
    ✔️ GenericGrep          modifier.name

[████████████████████████████████████████] 100% | 🕙 ETA: 0s | 1/1 | 🌲 0 | 🔥 0 | 🗂️  test.sol

   ────────────────────────────
{
  'test.sol': [
    {
      rule: 'GenericGrep',
      tag: 'match-modifier: ReEntrancyGuard.noReentrant',
      info: 'noReentrant',
      loc: [Array]
    }
  ]
}
```


⚠️ when using multi-options (`--find`, `--rule`) make sure to use this format:

```
⇒  solgrep <folder|...> [options]
```

or

```
⇒  solgrep [options] -- <folder|...> 
```

or else additional options might be interpreted as additional `--find` options!