### PR TITLE
Fixes fastq mandatory concurrency

### DIFF
--- a/src/solgrep.js
+++ b/src/solgrep.js
@@ -97,7 +97,7 @@ class SolGrep {
                 return resolve([]);
             }
 
-            const q = fastq(this, worker);
+            const q = fastq(this, worker, 1);
             q.drain = () => {
                 this.notify("onDirAnalyzed", targetDir);
                 this.notifyRules("onDirAnalyzed")


### PR DESCRIPTION
fastq complains about concurrency if not explicit:
```
Error: fastqueue concurrency must be equal to or greater than 1
    at fastqueue (/home/crystalin/.nvm/versions/node/v20.16.0/lib/node_modules/solgrep/node_modules/fastq/queue.js:15:11)
    at /home/crystalin/.nvm/versions/node/v20.16.0/lib/node_modules/solgrep/src/solgrep.js:100:23
    at new Promise (<anonymous>)
    at SolGrep.analyzeDirQueue (/home/crystalin/.nvm/versions/node/v20.16.0/lib/node_modules/solgrep/src/solgrep.js:91:16)
    at main (/home/crystalin/.nvm/versions/node/v20.16.0/lib/node_modules/solgrep/bin/main.js:143:29)
    at Object.<anonymous> (/home/crystalin/.nvm/versions/node/v20.16.0/lib/node_modules/solgrep/bin/main.js:167:1)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
 ```
 